### PR TITLE
Feature/update slide core #36

### DIFF
--- a/.changeset/chilly-ideas-flow.md
+++ b/.changeset/chilly-ideas-flow.md
@@ -1,0 +1,5 @@
+---
+"react-slide-craft": major
+---
+
+Create SlideObject

--- a/README.ja.md
+++ b/README.ja.md
@@ -85,6 +85,22 @@ const CustomSlideTemplate = ({
 }
 ```
 
+もし、自作のスライドを適用する際に`SlideCore`で定義したベーススタイルを一部適用したくない場合には、下記のように`SlideCore`の`slides`にわたす際に`genSlideObject`で作成したオブジェクトを配列に加えてください。
+```tsx
+const App = () => {
+  const slides = [
+    ComponentA,
+    genSlideObject(CustomSlide) // optionsのisBaseStyleでベーススタイルを切り替え
+  ]
+
+  return (
+    <SlideCore
+      slides={slides}
+    />
+  )
+}
+```
+
 ## Components
 ### Core
 - SlideCore

--- a/README.md
+++ b/README.md
@@ -89,6 +89,22 @@ const CustomSlideTemplate = ({
 }
 ```
 
+If you do not want to apply some of the base styles defined in `SlideCore` when applying your own slides, add objects created with `genSlideObject` to the array when passing to `slides` in `SlideCore` as shown below.
+```tsx
+const App = () => {
+  const slides = [
+    ComponentA,
+    genSlideObject(CustomSlide) // Toggle base style with options isBaseStyle
+  ]
+
+  return (
+    <SlideCore
+      slides={slides}
+    />
+  )
+}
+```
+
 ## Components
 ### Core
 - SlideCore

--- a/src/stories/components/SlideCore.stories.tsx
+++ b/src/stories/components/SlideCore.stories.tsx
@@ -5,6 +5,8 @@ import { SlideBase } from "../../components/core/SlideBase"
 import { CoverSlideTemplate } from "../../components/templates/CoverSlideTemplate"
 import { TitleAndBodySlideTemplate } from "../../components/templates/TitleAndBodySlideTemplate"
 import { TitleWithBgAndBodySlideTemplate } from "../../components/templates/TitleWithBgAndBodySlideTemplate"
+import { genSlideObject } from "../../utils/slideObject"
+import { TitleText } from "../../components"
 
 const slides = [
   () => (
@@ -24,6 +26,7 @@ const slides = [
   () => <CoverSlideTemplate title="Cover Slide Title\nHello" subTitle="HASURO" align="center" subTitleColor="gray" />,
   () => <TitleAndBodySlideTemplate title="Hello">d</TitleAndBodySlideTemplate>,
   () => <TitleWithBgAndBodySlideTemplate title="Hello">d</TitleWithBgAndBodySlideTemplate>,
+  genSlideObject(() => <TitleText text="Not Base Style" color="white" />),
 ]
 
 export default {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,1 @@
-export * from "./generateBaseSlideFrame"
+export { genSlideObject } from './slideObject'

--- a/src/utils/slideObject.tsx
+++ b/src/utils/slideObject.tsx
@@ -1,0 +1,34 @@
+import React, { JSX } from "react"
+import { Slide, SlideObject, SlideObjectOptions } from "../components"
+
+export const isJSXElementFunction = (fn: any): fn is () => JSX.Element => {
+  if (typeof fn !== 'function') return false;
+
+  try {
+    const result = fn();
+    return React.isValidElement(result);
+  } catch {
+    return false;
+  }
+}
+
+export const renderSlideComponent = (slide: Slide): (() => JSX.Element) => {
+  if (isJSXElementFunction(slide)) {
+    return slide
+  } else {
+    if (typeof slide === 'object' && 'render' in slide) {
+      return (slide as SlideObject).render;
+    }
+    return (): JSX.Element => <React.Fragment />
+  }
+}
+
+export const genSlideObject = (
+  component: () => JSX.Element,
+  options?: SlideObjectOptions,
+) => {
+  return {
+    render: component,
+    options: {...options, isBaseStyle: options?.isBaseStyle ?? false}
+  } as SlideObject
+}


### PR DESCRIPTION
## やったこと
- `SlideObject`の作成による、スライドごとのオプション切り替えが可能に
- ver1.0.0のリリース

## やっていないこと


## 影響範囲


## 補足


close #36